### PR TITLE
Lookup table for species that get dashes in the catch summary tables

### DIFF
--- a/ADFG_REPORT.Rmd
+++ b/ADFG_REPORT.Rmd
@@ -87,7 +87,7 @@ flextable::flextable(catch_sum_3nm, col_keys = c("common_name", "dummy_col", "to
       as_i(species_2),
       "", new_suffix
   )) %>%
-  flextable::add_header_lines("Table 1. 2024 Catch summary table - totals within 3-mile territorial waters (Alaska state waters); \"--\" indicates \"null\".", top = TRUE) %>%
+  flextable::add_header_lines("Table 1. 2024 Catch summary table - totals within 3-mile territorial waters (Alaska state waters); \"--\" indicates \"null\". Counts for sponges (phylum Porifera), bryozoans (phylum Bryozoa), ascidians (class Ascidiacea), and Anthozoans (subphylum Anthozoa) that are not anemones (order Actinaria) or sea pens (order Pennatulacea) are not provided, as these taxa are either colonial or not consistently counted in the bottom trawl survey.", top = TRUE) %>%
   flextable::font(fontname = "Times New Roman", part = "all") %>%
   flextable::fontsize(size = 12, part = "all") %>%
   flextable::theme_vanilla() %>%
@@ -154,7 +154,7 @@ flextable::flextable(catch_sum_all, col_keys = c("common_name", "dummy_col", "to
       as_i(species_2),
       "", new_suffix
   )) %>% 
-  flextable::add_header_lines("Table 2. 2024 Catch summary table - totals for survey (including state waters); \"--\" indicates \"null\".", top = TRUE) %>%
+  flextable::add_header_lines("Table 2. 2024 Catch summary table - totals for survey (including state waters); \"--\" indicates \"null\". Counts for sponges (phylum Porifera), bryozoans (phylum Bryozoa), ascidians (class Ascidiacea), and Anthozoans (subphylum Anthozoa) that are not anemones (order Actinaria) or sea pens (order Pennatulacea) are not provided, as these taxa are either colonial or not consistently counted in the bottom trawl survey.", top = TRUE) %>%
   flextable::font(fontname = "Times New Roman", part = "all") %>%
   flextable::fontsize(size = 12, part = "all") %>%
   flextable::theme_vanilla() %>%

--- a/ADFG_REPORT.Rmd
+++ b/ADFG_REPORT.Rmd
@@ -64,6 +64,7 @@ catch_sum_3nm <- catch_summary_3nm1 %>%
 # Round total counts and format with commas
 catch_sum_3nm$total_count <- format(round(catch_sum_3nm$total_count), big.mark = ",")
 catch_sum_3nm$total_count[which(catch_sum_3nm$total_count == "     0")] <- "--"
+catch_sum_3nm$total_count[which(catch_sum_3nm$species_code %in% dashes_lookup$species_code)] <- "--" #no counts for certain taxa
 
 # Round total weight and format with commas
 catch_sum_3nm$total_weight_kg_txt <- format(round(catch_sum_3nm$total_weight_kg, digits = 2), big.mark = ",")
@@ -128,6 +129,7 @@ catch_sum_all <- catch_summary1 %>%
 # Round total counts and format with commas
 catch_sum_all$total_count <-  format(round(catch_sum_all$total_count), big.mark = ",")  
 catch_sum_all$total_count[which(catch_sum_all$total_count=="      0")] <- "--"
+catch_sum_all$total_count[which(catch_sum_all$species_code %in% dashes_lookup$species_code)] <- "--" #no counts for certain taxa
 
 # Round total weight and format with commas
 catch_sum_all$total_weight_kg_txt <-  format(round(catch_sum_all$total_weight_kg,digits = 2), big.mark = ",")

--- a/data.R
+++ b/data.R
@@ -193,16 +193,15 @@ invert_taxa_all_count <- voucher_count %>%  dplyr::mutate(taxon = dplyr::case_wh
   species_code >= 40001 ~ "invert"     
 )) %>% dplyr::filter(taxon == "invert") %>% nrow()
 
-# Lookup table for species that won't get counts in the tables ------------
+# Lookup table for species that won't get counts in catch summary tables -------
 dashes_lookup <- taxonomy0 |>
-  dplyr::filter(survey_species==1) |>
-  mutate(no_counts = case_when(phylum_taxon %in% c("Porifera","Bryozoa") ~ 1,
-                               class_taxon == "Ascidiacea" ~ 1,
-                               subphylum_taxon == "Anthozoa" & 
-                                 order_taxon != "Actiniaria" & 
-                                 order_taxon != "Pennatulacea" ~ 1,
-                               TRUE ~ 0
-                               )
-         ) |>
+  dplyr::filter(survey_species == 1) |>
+  mutate(no_counts = case_when(
+    phylum_taxon %in% c("Porifera", "Bryozoa") ~ 1,
+    class_taxon == "Ascidiacea" ~ 1,
+    subphylum_taxon == "Anthozoa" &
+      order_taxon != "Actiniaria" &
+      order_taxon != "Pennatulacea" ~ 1,
+    TRUE ~ 0
+  )) |>
   dplyr::filter(no_counts == 1)
-  

--- a/data.R
+++ b/data.R
@@ -193,3 +193,16 @@ invert_taxa_all_count <- voucher_count %>%  dplyr::mutate(taxon = dplyr::case_wh
   species_code >= 40001 ~ "invert"     
 )) %>% dplyr::filter(taxon == "invert") %>% nrow()
 
+# Lookup table for species that won't get counts in the tables ------------
+dashes_lookup <- taxonomy0 |>
+  dplyr::filter(survey_species==1) |>
+  mutate(no_counts = case_when(phylum_taxon %in% c("Porifera","Bryozoa") ~ 1,
+                               class_taxon == "Ascidiacea" ~ 1,
+                               subphylum_taxon == "Anthozoa" & 
+                                 order_taxon != "Actiniaria" & 
+                                 order_taxon != "Pennatulacea" ~ 1,
+                               TRUE ~ 0
+                               )
+         ) |>
+  dplyr::filter(no_counts == 1)
+  

--- a/data_dl.R
+++ b/data_dl.R
@@ -14,7 +14,10 @@ locations <- c(
   # "RACE_DATA.CRUISES",
   "RACE_DATA.V_CRUISES",
   # "GOA.STATIONS_3NM" #hastag out depending on what year your are reporting
-  "AI.STATIONS_3NM" #hashtag out depending on what year your are reporting, maybe create IF ELSE statement
+  "AI.STATIONS_3NM", #hashtag out depending on what year your are reporting, maybe create IF ELSE statement
+  
+  # GAP_PRODUCTS tables
+  "GAP_PRODUCTS.TAXONOMIC_CLASSIFICATION"
 )
 
 

--- a/read.R
+++ b/read.R
@@ -138,4 +138,3 @@ voucher_count <- catch0 %>%
 voucher_all <- dplyr::bind_rows(voucher_count, age_count) %>%
   dplyr::left_join(species0) %>%
   dplyr::select(common_name, species_name, count, comment)
-

--- a/run.R
+++ b/run.R
@@ -14,6 +14,7 @@ specimen0 <- read.csv("./data/oracle/racebase-specimen.csv") %>% janitor::clean_
 species0 <- read.csv("./data/oracle/racebase-species.csv") %>% janitor::clean_names()
 stations_3nm0 <- read.csv("./data/oracle/ai-stations_3nm.csv") %>% janitor::clean_names()
 # stations_3nm0 <- read.csv("./data/oracle/goa-stations_3nm.csv") %>% janitor::clean_names() odd years only
+taxonomy0 <- read.csv("./data/oracle/gap_products-taxonomic_classification.csv") %>% janitor::clean_names()
 
 # --------------------------
 # Update based on survey and year 

--- a/run.R
+++ b/run.R
@@ -27,7 +27,7 @@ cruise1 <- "202401"
 
 # -------------------
 source('./read.R') #creates tables needed for document
-source('./data.R') #anaylsis of data for document
+source('./data.R') #analysis of data for document
 
 
 # -----------------------------


### PR DESCRIPTION
These edits add a taxonomic lookup table (in data.R) that is used in the Rmd file to add "--" in the catch summary table for species that shouldn't have counts provided (currently, sponges, bryozoans, ascidians, anthozoa that aren't anemones or sea pens). 